### PR TITLE
Remove recursive call in uvm_init

### DIFF
--- a/src/base/uvm_globals.svh
+++ b/src/base/uvm_globals.svh
@@ -339,7 +339,12 @@ function void uvm_init(uvm_coreservice_t cs=null);
       // as a warning.  We only report it if the value for ~cs~ is _not_
       // the current core service, and ~cs~ is not null.
       uvm_coreservice_t actual;
+`ifdef VERILATOR
+      // If it is a subsequent call, uvm_coreservice_t::get returns uvm_coreservice_t::inst, but there is no recursion.
+      actual = uvm_coreservice_t::inst;
+`else
       actual = uvm_coreservice_t::get();
+`endif
       if ((cs != actual) && (cs != null))
         `uvm_warning("UVM/INIT/MULTI", "uvm_init() called after library has already completed initialization, subsequent calls are ignored!")
     end


### PR DESCRIPTION
Verilator currently doesn't support recursive function calls. There is only 1 such call in UVM and I prepared a workaround.
This recursive call was used only to detect a subsequent call of `uvm_init`. If it is a subsequent call, `uvm_coreservice_t::get()` returns its static field `inst`, which is set a few lines after the line I modified:
https://github.com/chipsalliance/uvm-verilator/blob/1993861f4e1c5d17d5be4a951249913ba7fcde77/src/base/uvm_globals.svh#L362