### PR TITLE
Workaround calls of type_id::create

### DIFF
--- a/src/base/uvm_field_op.svh
+++ b/src/base/uvm_field_op.svh
@@ -170,7 +170,11 @@ class uvm_field_op extends uvm_object;
    static function uvm_field_op m_get_available_op() ;
       uvm_field_op field_op ;
       if (m_recycled_op.size() > 0) field_op = m_recycled_op.pop_back() ;
+`ifdef VERILATOR
+      else field_op = uvm_field_op::type_id_create("field_op");
+`else
       else field_op = uvm_field_op::type_id::create("field_op");
+`endif
       return field_op ;
    endfunction
 endclass

--- a/src/base/uvm_objection.svh
+++ b/src/base/uvm_objection.svh
@@ -1038,6 +1038,13 @@ class uvm_objection extends uvm_report_object;
   // for factory registration, printing, comparing, etc.
 
   typedef uvm_object_registry#(uvm_objection,"uvm_objection") type_id;
+`ifdef VERILATOR
+  static function uvm_objection type_id_create (string name="",
+                                                uvm_component parent=null,
+                                                string contxt="");
+    return type_id::create(name, parent, contxt);
+  endfunction
+`endif
   static function type_id get_type();
     return type_id::get();
   endfunction
@@ -1135,7 +1142,11 @@ class uvm_test_done_objection extends uvm_objection;
 
   static function uvm_test_done_objection get();
     if(m_inst == null)
+ `ifdef VERILATOR
+      m_inst = uvm_test_done_objection::type_id_create("run");
+ `else
       m_inst = uvm_test_done_objection::type_id::create("run");
+ `endif
     return m_inst;
   endfunction
 

--- a/src/base/uvm_phase.svh
+++ b/src/base/uvm_phase.svh
@@ -580,10 +580,18 @@ class uvm_phase extends uvm_object;
               phase_done = uvm_test_done_objection::get();
 	   end
 	   else begin
+ `ifdef VERILATOR
+              phase_done = uvm_objection::type_id_create({get_name(), "_objection"});
+ `else
               phase_done = uvm_objection::type_id::create({get_name(), "_objection"});
+ `endif
 	   end
 `else // !UVM_ENABLE_DEPRECATED_API
-	   phase_done = uvm_objection::type_id::create({get_name(), "_objection"});
+ `ifdef VERILATOR
+        phase_done = uvm_objection::type_id_create({get_name(), "_objection"});
+ `else
+	phase_done = uvm_objection::type_id::create({get_name(), "_objection"});
+ `endif
 `endif // UVM_ENABLE_DEPRECATED_API
      end
      
@@ -978,7 +986,11 @@ function void uvm_phase::add(uvm_phase phase,
   else
     tmp_node = new_node;
 
-  state_chg = uvm_phase_state_change::type_id::create(tmp_node.get_name());
+`ifdef VERILATOR
+   state_chg = uvm_phase_state_change::type_id_create(tmp_node.get_name());
+`else
+   state_chg = uvm_phase_state_change::type_id::create(tmp_node.get_name());
+`endif
   state_chg.m_phase = tmp_node;
   state_chg.m_jump_to = null;
   state_chg.m_prev_state = tmp_node.m_state;
@@ -1337,7 +1349,11 @@ task uvm_phase::execute_phase();
   if (m_state == UVM_PHASE_DONE)
     return;
 
-  state_chg = uvm_phase_state_change::type_id::create(get_name());
+`ifdef VERILATOR
+   state_chg = uvm_phase_state_change::type_id_create(get_name());
+`else
+   state_chg = uvm_phase_state_change::type_id::create(get_name());
+`endif
   state_chg.m_phase      = this;
   state_chg.m_jump_to    = null;
 

--- a/src/base/uvm_report_object.svh
+++ b/src/base/uvm_report_object.svh
@@ -91,7 +91,11 @@ class uvm_report_object extends uvm_object;
   local bit m_rh_set;
   local function void m_rh_init();
     if (!m_rh_set)
+`ifdef VERILATOR
+      set_report_handler(uvm_report_handler::type_id_create(get_name()));
+`else
       set_report_handler(uvm_report_handler::type_id::create(get_name()));
+`endif
   endfunction : m_rh_init
 
   // Function -- NODOCS -- new

--- a/src/base/uvm_text_tr_database.svh
+++ b/src/base/uvm_text_tr_database.svh
@@ -132,7 +132,11 @@ class uvm_text_tr_database extends uvm_tr_database;
    protected virtual function uvm_tr_stream do_open_stream(string name,
                                                            string scope,
                                                            string type_name);
+`ifdef VERILATOR
+      uvm_text_tr_stream m_stream = uvm_text_tr_stream::type_id_create(name);
+`else
       uvm_text_tr_stream m_stream = uvm_text_tr_stream::type_id::create(name);
+`endif
       return m_stream;
    endfunction : do_open_stream
 

--- a/src/base/uvm_text_tr_stream.svh
+++ b/src/base/uvm_text_tr_stream.svh
@@ -112,7 +112,11 @@ class uvm_text_tr_stream extends uvm_tr_stream;
                                                            time   open_time,
                                                            string type_name);
       if (m_text_db.open_db()) begin
+`ifdef VERILATOR
+         return uvm_text_recorder::type_id_create(name);
+`else
          return uvm_text_recorder::type_id::create(name);
+`endif
       end
 
       return null;

--- a/src/macros/uvm_object_defines.svh
+++ b/src/macros/uvm_object_defines.svh
@@ -448,6 +448,22 @@ endfunction : __m_uvm_execute_field_op
 // family of macros uses this macro.
 
 // @uvm-ieee 1800.2-2017 auto B.2.1.4
+
+`ifdef VERILATOR
+`define uvm_object_registry(T,S) \
+   typedef uvm_object_registry#(T,S) type_id; \
+   static function T type_id_create (string name="", \
+                                     uvm_component parent=null, \
+                                     string contxt=""); \
+     return type_id::create(name, parent, contxt); \
+   endfunction \
+   static function type_id get_type(); \
+     return type_id::get(); \
+   endfunction \
+   virtual function uvm_object_wrapper get_object_type(); \
+     return type_id::get(); \
+   endfunction
+`else
 `define uvm_object_registry(T,S) \
    typedef uvm_object_registry#(T,S) type_id; \
    static function type_id get_type(); \
@@ -456,7 +472,7 @@ endfunction : __m_uvm_execute_field_op
    virtual function uvm_object_wrapper get_object_type(); \
      return type_id::get(); \
    endfunction
-
+`endif
 
 // MACRO -- NODOCS -- `uvm_component_registry
 //
@@ -470,6 +486,21 @@ endfunction : __m_uvm_execute_field_op
 // family of macros uses this macro.
 
 // @uvm-ieee 1800.2-2017 auto B.2.1.5
+`ifdef VERILATOR
+`define uvm_component_registry(T,S) \
+   typedef uvm_component_registry #(T,S) type_id; \
+   static function T type_id_create (string name="", \
+                                     uvm_component parent=null, \
+                                     string contxt=""); \
+     return type_id::create(name, parent, contxt); \
+   endfunction \
+   static function type_id get_type(); \
+     return type_id::get(); \
+   endfunction \
+   virtual function uvm_object_wrapper get_object_type(); \
+     return type_id::get(); \
+   endfunction
+`else
 `define uvm_component_registry(T,S) \
    typedef uvm_component_registry #(T,S) type_id; \
    static function type_id get_type(); \
@@ -478,7 +509,7 @@ endfunction : __m_uvm_execute_field_op
    virtual function uvm_object_wrapper get_object_type(); \
      return type_id::get(); \
    endfunction
-
+`endif
 
 `define uvm_declare_type_alias(TYPE,NAME,SFX=) \
   static bit m__alias_declared``SFX = TYPE::type_id::set_type_alias(NAME);
@@ -547,6 +578,21 @@ endfunction : __m_uvm_execute_field_op
 
 //This is needed due to an issue in of passing down strings
 //created by args to lower level macros.
+`ifdef VERILATOR
+`define m_uvm_object_registry_internal(T,S) \
+   typedef uvm_object_registry#(T,`"S`") type_id; \
+   static function T type_id_create (string name="", \
+                                     uvm_component parent=null, \
+                                     string contxt=""); \
+     return type_id::create(name, parent, contxt); \
+   endfunction \
+   static function type_id get_type(); \
+     return type_id::get(); \
+   endfunction \
+   virtual function uvm_object_wrapper get_object_type(); \
+     return type_id::get(); \
+   endfunction
+`else
 `define m_uvm_object_registry_internal(T,S) \
    typedef uvm_object_registry#(T,`"S`") type_id; \
    static function type_id get_type(); \
@@ -555,7 +601,7 @@ endfunction : __m_uvm_execute_field_op
    virtual function uvm_object_wrapper get_object_type(); \
      return type_id::get(); \
    endfunction
-
+`endif
 
 // m_uvm_object_registry_param
 // ---------------------------

--- a/src/reg/sequences/uvm_mem_access_seq.svh
+++ b/src/reg/sequences/uvm_mem_access_seq.svh
@@ -231,7 +231,11 @@ class uvm_mem_access_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg_item)
 
       uvm_report_info("STARTING_SEQ",{"\n\nStarting ",get_name()," sequence...\n"},UVM_LOW);
       
+`ifdef VERILATOR
+      mem_seq = uvm_mem_single_access_seq::type_id_create("single_mem_access_seq");
+`else
       mem_seq = uvm_mem_single_access_seq::type_id::create("single_mem_access_seq");
+`endif
 
       this.reset_blk(model);
       model.reset();

--- a/src/reg/sequences/uvm_mem_walk_seq.svh
+++ b/src/reg/sequences/uvm_mem_walk_seq.svh
@@ -234,7 +234,11 @@ class uvm_mem_walk_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg_item));
 
       uvm_report_info("STARTING_SEQ",{"\n\nStarting ",get_name()," sequence...\n"},UVM_LOW);
 
+`ifdef VERILATOR
+      mem_seq = uvm_mem_single_walk_seq::type_id_create("single_mem_walk_seq");
+`else
       mem_seq = uvm_mem_single_walk_seq::type_id::create("single_mem_walk_seq");
+`endif
 
       this.reset_blk(model);
       model.reset();

--- a/src/reg/sequences/uvm_reg_access_seq.svh
+++ b/src/reg/sequences/uvm_reg_access_seq.svh
@@ -231,7 +231,11 @@ class uvm_reg_access_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg_item)
 
       uvm_report_info("STARTING_SEQ",{"\n\nStarting ",get_name()," sequence...\n"},UVM_LOW);
       
+`ifdef VERILATOR
+      reg_seq = uvm_reg_single_access_seq::type_id_create("single_reg_access_seq");
+`else
       reg_seq = uvm_reg_single_access_seq::type_id::create("single_reg_access_seq");
+`endif
 
       this.reset_blk(model);
       model.reset();

--- a/src/reg/sequences/uvm_reg_bit_bash_seq.svh
+++ b/src/reg/sequences/uvm_reg_bit_bash_seq.svh
@@ -241,7 +241,11 @@ class uvm_reg_bit_bash_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg_ite
 
       uvm_report_info("STARTING_SEQ",{"\n\nStarting ",get_name()," sequence...\n"},UVM_LOW);
 
+`ifdef VERILATOR
+      reg_seq = uvm_reg_single_bit_bash_seq::type_id_create("reg_single_bit_bash_seq");
+`else
       reg_seq = uvm_reg_single_bit_bash_seq::type_id::create("reg_single_bit_bash_seq");
+`endif
 
       this.reset_blk(model);
       model.reset();

--- a/src/reg/sequences/uvm_reg_mem_built_in_seq.svh
+++ b/src/reg/sequences/uvm_reg_mem_built_in_seq.svh
@@ -75,7 +75,11 @@ class uvm_reg_mem_built_in_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg
                                              "NO_REG_TESTS", 0) == null &&
           uvm_resource_db#(bit)::get_by_name({"REG::",model.get_full_name()},
                                              "NO_REG_HW_RESET_TEST", 0) == null ) begin
-        uvm_reg_hw_reset_seq seq = uvm_reg_hw_reset_seq::type_id::create("reg_hw_reset_seq");
+`ifdef VERILATOR
+         uvm_reg_hw_reset_seq seq = uvm_reg_hw_reset_seq::type_id_create("reg_hw_reset_seq");
+`else
+         uvm_reg_hw_reset_seq seq = uvm_reg_hw_reset_seq::type_id::create("reg_hw_reset_seq");
+`endif
         seq.model = model;
         seq.start(null,this);
         `uvm_info("FINISH_SEQ",{"Finished ",seq.get_name()," sequence."},UVM_LOW)
@@ -86,7 +90,11 @@ class uvm_reg_mem_built_in_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg
                                              "NO_REG_TESTS", 0) == null &&
           uvm_resource_db#(bit)::get_by_name({"REG::",model.get_full_name()},
                                              "NO_REG_BIT_BASH_TEST", 0) == null ) begin
-        uvm_reg_bit_bash_seq seq = uvm_reg_bit_bash_seq::type_id::create("reg_bit_bash_seq");
+`ifdef VERILATOR
+         uvm_reg_bit_bash_seq seq = uvm_reg_bit_bash_seq::type_id_create("reg_bit_bash_seq");
+`else
+         uvm_reg_bit_bash_seq seq = uvm_reg_bit_bash_seq::type_id::create("reg_bit_bash_seq");
+`endif
         seq.model = model;
         seq.start(null,this);
         `uvm_info("FINISH_SEQ",{"Finished ",seq.get_name()," sequence."},UVM_LOW)
@@ -97,7 +105,11 @@ class uvm_reg_mem_built_in_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg
                                              "NO_REG_TESTS", 0) == null &&
           uvm_resource_db#(bit)::get_by_name({"REG::",model.get_full_name()},
                                              "NO_REG_ACCESS_TEST", 0) == null ) begin
-        uvm_reg_access_seq seq = uvm_reg_access_seq::type_id::create("reg_access_seq");
+`ifdef VERILATOR
+         uvm_reg_access_seq seq = uvm_reg_access_seq::type_id_create("reg_access_seq");
+`else
+         uvm_reg_access_seq seq = uvm_reg_access_seq::type_id::create("reg_access_seq");
+`endif
         seq.model = model;
         seq.start(null,this);
         `uvm_info("FINISH_SEQ",{"Finished ",seq.get_name()," sequence."},UVM_LOW)
@@ -110,7 +122,11 @@ class uvm_reg_mem_built_in_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg
                                              "NO_MEM_TESTS", 0) == null &&
           uvm_resource_db#(bit)::get_by_name({"REG::",model.get_full_name()},
                                              "NO_MEM_ACCESS_TEST", 0) == null ) begin
-        uvm_mem_access_seq seq = uvm_mem_access_seq::type_id::create("mem_access_seq");
+`ifdef VERILATOR
+         uvm_mem_access_seq seq = uvm_mem_access_seq::type_id_create("mem_access_seq");
+`else
+         uvm_mem_access_seq seq = uvm_mem_access_seq::type_id::create("mem_access_seq");
+`endif
         seq.model = model;
         seq.start(null,this);
         `uvm_info("FINISH_SEQ",{"Finished ",seq.get_name()," sequence."},UVM_LOW)
@@ -121,7 +137,11 @@ class uvm_reg_mem_built_in_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg
                                              "NO_REG_TESTS", 0) == null &&
           uvm_resource_db#(bit)::get_by_name({"REG::",model.get_full_name()},
                                              "NO_REG_SHARED_ACCESS_TEST", 0) == null ) begin
-        uvm_reg_mem_shared_access_seq seq = uvm_reg_mem_shared_access_seq::type_id::create("shared_access_seq");
+`ifdef VERILATOR
+         uvm_reg_mem_shared_access_seq seq = uvm_reg_mem_shared_access_seq::type_id_create("shared_access_seq");
+`else
+         uvm_reg_mem_shared_access_seq seq = uvm_reg_mem_shared_access_seq::type_id::create("shared_access_seq");
+`endif
         seq.model = model;
         seq.start(null,this);
         `uvm_info("FINISH_SEQ",{"Finished ",seq.get_name()," sequence."},UVM_LOW)
@@ -132,7 +152,11 @@ class uvm_reg_mem_built_in_seq extends uvm_reg_sequence #(uvm_sequence #(uvm_reg
                                              "NO_REG_TESTS", 0) == null &&
           uvm_resource_db#(bit)::get_by_name({"REG::",model.get_full_name()},
                                              "NO_MEM_WALK_TEST", 0) == null ) begin
-        uvm_mem_walk_seq seq = uvm_mem_walk_seq::type_id::create("mem_walk_seq");
+`ifdef VERILATOR
+         uvm_mem_walk_seq seq = uvm_mem_walk_seq::type_id_create("mem_walk_seq");
+`else
+         uvm_mem_walk_seq seq = uvm_mem_walk_seq::type_id::create("mem_walk_seq");
+`endif
         seq.model = model;
         seq.start(null,this);
         `uvm_info("FINISH_SEQ",{"Finished ",seq.get_name()," sequence."},UVM_LOW)

--- a/src/reg/sequences/uvm_reg_mem_shared_access_seq.svh
+++ b/src/reg/sequences/uvm_reg_mem_shared_access_seq.svh
@@ -400,8 +400,13 @@ class uvm_reg_mem_shared_access_seq extends uvm_reg_sequence #(uvm_sequence #(uv
       
       uvm_report_info("STARTING_SEQ",{"\n\nStarting ",get_name()," sequence...\n"},UVM_LOW);
 
+`ifdef VERILATOR
+      reg_seq = uvm_reg_shared_access_seq::type_id_create("reg_shared_access_seq");
+      mem_seq = uvm_mem_shared_access_seq::type_id_create("reg_shared_access_seq");
+`else
       reg_seq = uvm_reg_shared_access_seq::type_id::create("reg_shared_access_seq");
       mem_seq = uvm_mem_shared_access_seq::type_id::create("reg_shared_access_seq");
+`endif
 
       this.reset_blk(model);
       model.reset();

--- a/src/reg/uvm_mem.svh
+++ b/src/reg/uvm_mem.svh
@@ -1035,7 +1035,11 @@ task uvm_mem::write(output uvm_status_e      status,
                     input  int               lineno = 0);
 
    // create an abstract transaction for this operation
+`ifdef VERILATOR
+   uvm_reg_item rw = uvm_reg_item::type_id_create("mem_write",,get_full_name());
+`else
    uvm_reg_item rw = uvm_reg_item::type_id::create("mem_write",,get_full_name());
+`endif
    rw.element      = this;
    rw.element_kind = UVM_MEM;
    rw.kind         = UVM_WRITE;
@@ -1070,7 +1074,11 @@ task uvm_mem::read(output uvm_status_e       status,
                    input  int                lineno = 0);
    
    uvm_reg_item rw;
+`ifdef VERILATOR
+   rw = uvm_reg_item::type_id_create("mem_read",,get_full_name());
+`else
    rw = uvm_reg_item::type_id::create("mem_read",,get_full_name());
+`endif
    rw.element      = this;
    rw.element_kind = UVM_MEM;
    rw.kind         = UVM_READ;
@@ -1106,7 +1114,11 @@ task uvm_mem::burst_write(output uvm_status_e       status,
                           input  int                lineno = 0);
 
    uvm_reg_item rw;
+`ifdef VERILATOR
+   rw = uvm_reg_item::type_id_create("mem_burst_write",,get_full_name());
+`else
    rw = uvm_reg_item::type_id::create("mem_burst_write",,get_full_name());
+`endif
    rw.element      = this;
    rw.element_kind = UVM_MEM;
    rw.kind         = UVM_BURST_WRITE;
@@ -1141,7 +1153,11 @@ task uvm_mem::burst_read(output uvm_status_e       status,
                          input  int                lineno = 0);
 
    uvm_reg_item rw;
+`ifdef VERILATOR
+   rw = uvm_reg_item::type_id_create("mem_burst_read",,get_full_name());
+`else
    rw = uvm_reg_item::type_id::create("mem_burst_read",,get_full_name());
+`endif
    rw.element      = this;
    rw.element_kind = UVM_MEM;
    rw.kind         = UVM_BURST_READ;
@@ -1487,7 +1503,11 @@ task uvm_mem::poke(output uvm_status_e      status,
    end
 
    // create an abstract transaction for this operation
+`ifdef VERILATOR
+   rw = uvm_reg_item::type_id_create("mem_poke_item",,get_full_name());
+`else
    rw = uvm_reg_item::type_id::create("mem_poke_item",,get_full_name());
+`endif
    rw.element      = this;
    rw.path         = UVM_BACKDOOR;
    rw.element_kind = UVM_MEM;
@@ -1537,7 +1557,11 @@ task uvm_mem::peek(output uvm_status_e      status,
    end
 
    // create an abstract transaction for this operation
+`ifdef VERILATOR
+   rw = uvm_reg_item::type_id_create("mem_peek_item",,get_full_name());
+`else
    rw = uvm_reg_item::type_id::create("mem_peek_item",,get_full_name());
+`endif
    rw.element      = this;
    rw.path         = UVM_BACKDOOR;
    rw.element_kind = UVM_MEM;

--- a/src/reg/uvm_reg.svh
+++ b/src/reg/uvm_reg.svh
@@ -1552,7 +1552,11 @@ task uvm_reg::write(output uvm_status_e      status,
 
    set(value);
 
+`ifdef VERILATOR
+   rw = uvm_reg_item::type_id_create("write_item",,get_full_name());
+`else
    rw = uvm_reg_item::type_id::create("write_item",,get_full_name());
+`endif
    rw.element      = this;
    rw.element_kind = UVM_REG;
    rw.kind         = UVM_WRITE;
@@ -1807,7 +1811,11 @@ task uvm_reg::XreadX(output uvm_status_e      status,
    
    // create an abstract transaction for this operation
    uvm_reg_item rw;
+`ifdef VERILATOR
+   rw = uvm_reg_item::type_id_create("read_item",,get_full_name());
+`else
    rw = uvm_reg_item::type_id::create("read_item",,get_full_name());
+`endif
    rw.element      = this;
    rw.element_kind = UVM_REG;
    rw.kind         = UVM_READ;
@@ -2250,7 +2258,11 @@ task uvm_reg::poke(output uvm_status_e      status,
      XatomicX(1);
 
    // create an abstract transaction for this operation
+`ifdef VERILATOR
+   rw = uvm_reg_item::type_id_create("reg_poke_item",,get_full_name());
+`else
    rw = uvm_reg_item::type_id::create("reg_poke_item",,get_full_name());
+`endif
    rw.element      = this;
    rw.path         = UVM_BACKDOOR;
    rw.element_kind = UVM_REG;
@@ -2307,7 +2319,11 @@ task uvm_reg::peek(output uvm_status_e      status,
       XatomicX(1);
 
    // create an abstract transaction for this operation
+`ifdef VERILATOR
+   rw = uvm_reg_item::type_id_create("mem_peek_item",,get_full_name());
+`else
    rw = uvm_reg_item::type_id::create("mem_peek_item",,get_full_name());
+`endif
    rw.element      = this;
    rw.path         = UVM_BACKDOOR;
    rw.element_kind = UVM_REG;

--- a/src/reg/uvm_reg_adapter.svh
+++ b/src/reg/uvm_reg_adapter.svh
@@ -187,7 +187,11 @@ class uvm_reg_tlm_adapter extends uvm_reg_adapter;
   // @uvm-ieee 1800.2-2017 auto 19.2.2.2.1
   virtual function uvm_sequence_item reg2bus(const ref uvm_reg_bus_op rw);
 
+`ifdef VERILATOR
+     uvm_tlm_gp gp = uvm_tlm_gp::type_id_create("tlm_gp",, this.get_full_name());
+`else
      uvm_tlm_gp gp = uvm_tlm_gp::type_id::create("tlm_gp",, this.get_full_name());
+`endif
      int nbytes = (rw.n_bits-1)/8+1;
      uvm_reg_addr_t addr=rw.addr;
 

--- a/src/reg/uvm_reg_block.svh
+++ b/src/reg/uvm_reg_block.svh
@@ -1873,7 +1873,11 @@ function uvm_reg_map uvm_reg_block::create_map(string name,
 
    uvm_reg_map  map;
 
+`ifdef VERILATOR
+   map = uvm_reg_map::type_id_create(name,,this.get_full_name());
+`else
    map = uvm_reg_map::type_id::create(name,,this.get_full_name());
+`endif
    map.configure(this,base_addr,n_bytes,endian,byte_addressing);
 
    add_map(map);

--- a/src/reg/uvm_reg_field.svh
+++ b/src/reg/uvm_reg_field.svh
@@ -1049,7 +1049,11 @@ task uvm_reg_field::write(output uvm_status_e       status,
                           input  int                lineno = 0);
 
    uvm_reg_item rw;
+`ifdef VERILATOR
+   rw = uvm_reg_item::type_id_create("field_write_item",,get_full_name());
+`else
    rw = uvm_reg_item::type_id::create("field_write_item",,get_full_name());
+`endif
    rw.element      = this;
    rw.element_kind = UVM_FIELD;
    rw.kind         = UVM_WRITE;
@@ -1197,7 +1201,11 @@ task uvm_reg_field::read(output uvm_status_e       status,
                          input  int                lineno = 0);
 
    uvm_reg_item rw;
+`ifdef VERILATOR
+   rw = uvm_reg_item::type_id_create("field_read_item",,get_full_name());
+`else
    rw = uvm_reg_item::type_id::create("field_read_item",,get_full_name());
+`endif
    rw.element      = this;
    rw.element_kind = UVM_FIELD;
    rw.kind         = UVM_READ;

--- a/src/reg/uvm_reg_fifo.svh
+++ b/src/reg/uvm_reg_fifo.svh
@@ -76,7 +76,11 @@ class uvm_reg_fifo extends uvm_reg;
     // the instantiating block, a <uvm_reg_block> subtype.
     //
     virtual function void build();
-        value = uvm_reg_field::type_id::create("value");
+`ifdef VERILATOR
+       value = uvm_reg_field::type_id_create("value");
+`else
+       value = uvm_reg_field::type_id::create("value");
+`endif
         value.configure(this, get_n_bits(), 0, "RW", 0, 32'h0, 1, 0, 1);
     endfunction
 

--- a/src/reg/uvm_reg_indirect.svh
+++ b/src/reg/uvm_reg_indirect.svh
@@ -174,7 +174,11 @@ class uvm_reg_indirect_data extends uvm_reg;
 
          XatomicX(1);
 
+`ifdef VERILATOR
+         rw = uvm_reg_item::type_id_create("write_item",,get_full_name());
+`else
          rw = uvm_reg_item::type_id::create("write_item",,get_full_name());
+`endif
          rw.element      = this;
          rw.element_kind = UVM_REG;
          rw.kind         = UVM_WRITE;

--- a/src/reg/uvm_reg_predictor.svh
+++ b/src/reg/uvm_reg_predictor.svh
@@ -118,7 +118,11 @@ class uvm_reg_predictor #(type BUSTYPE=int) extends uvm_component;
   virtual function string get_type_name();
     if (type_name == "") begin
       BUSTYPE t;
-      t = BUSTYPE::type_id::create("t");
+ `ifdef VERILATOR
+       t = BUSTYPE::type_id_create("t");
+ `else
+       t = BUSTYPE::type_id::create("t");
+ `endif
       type_name = {"uvm_reg_predictor #(", t.get_type_name(), ")"};
     end
     return type_name;
@@ -130,7 +134,11 @@ class uvm_reg_predictor #(type BUSTYPE=int) extends uvm_component;
     static string m_type_name;
     if (m_type_name == "") begin
       BUSTYPE t;
-      t = BUSTYPE::type_id::create("t");
+ `ifdef VERILATOR
+       t = BUSTYPE::type_id_create("t");
+ `else
+       t = BUSTYPE::type_id::create("t");
+ `endif
       m_type_name = {"uvm_reg_predictor #(", t.get_type_name(), ")"};
     end
     return m_type_name;

--- a/src/seq/uvm_sequence_base.svh
+++ b/src/seq/uvm_sequence_base.svh
@@ -563,8 +563,13 @@ virtual class uvm_sequence_base extends uvm_sequence_item;
      string sp_name = $sformatf("%s.starting_phase", get_full_name());
 
      if (create) begin
+`ifdef VERILATOR
+        m_automatic_phase_objection_dap = uvm_get_to_lock_dap#(bit)::type_id_create(apo_name, get_sequencer());
+        m_starting_phase_dap = uvm_get_to_lock_dap#(uvm_phase)::type_id_create(sp_name, get_sequencer());
+`else
         m_automatic_phase_objection_dap = uvm_get_to_lock_dap#(bit)::type_id::create(apo_name, get_sequencer());
         m_starting_phase_dap = uvm_get_to_lock_dap#(uvm_phase)::type_id::create(sp_name, get_sequencer());
+`endif
      end
      else begin
         m_automatic_phase_objection_dap.set_name(apo_name);


### PR DESCRIPTION
It removes a problem with `type_id::create` calls. Verilator needs to know the type of `type_id` token when `<class name>::type_id::create` references are parsed. Unfortunately, `type_id` definitions are read after some of the references, so it doesn't know the type in such cases.
Here is a minimal example to reproduce the problem:
```systemverilog
typedef class Bar;

class Baz;
  function int get_2;
     return 2 * Bar::type_id::get_1();
  endfunction
endclass

class Foo;
  static function int get_1;
    return 1;
  endfunction
endclass

class Bar;
  typedef Foo type_id;
endclass
```
I think it would take much time to fix it in Verilator, but I omitted the problem by modifying the UVM source code.