### PR TITLE
Revert workarounds that aren't needed

### DIFF
--- a/src/base/uvm_coreservice.svh
+++ b/src/base/uvm_coreservice.svh
@@ -168,11 +168,7 @@ virtual class uvm_coreservice_t;
 
 	pure virtual function int unsigned get_resource_pool_default_precedence();
 
-`ifdef VERILATOR
-	static uvm_coreservice_t inst;
-`else
 	local static uvm_coreservice_t inst;
-`endif
 
 	// @uvm-ieee 1800.2-2017 auto F.4.1.3
 	static function uvm_coreservice_t get();

--- a/src/base/uvm_globals.svh
+++ b/src/base/uvm_globals.svh
@@ -339,12 +339,7 @@ function void uvm_init(uvm_coreservice_t cs=null);
       // as a warning.  We only report it if the value for ~cs~ is _not_
       // the current core service, and ~cs~ is not null.
       uvm_coreservice_t actual;
-`ifdef VERILATOR
-      // If it is a subsequent call, uvm_coreservice_t::get returns uvm_coreservice_t::inst, but there is no recursion.
-      actual = uvm_coreservice_t::inst;
-`else
       actual = uvm_coreservice_t::get();
-`endif
       if ((cs != actual) && (cs != null))
         `uvm_warning("UVM/INIT/MULTI", "uvm_init() called after library has already completed initialization, subsequent calls are ignored!")
     end


### PR DESCRIPTION
Since recursive functions are supported, these workarounds aren't needed anymore.